### PR TITLE
Add GRP2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.6.0
 before_install: gem install bundler -v 1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,33 +1,44 @@
 PATH
   remote: .
   specs:
-    cgi_party (1.1.0)
-      savon (~> 2.0)
+    cgi_party (2.0.0)
+      rqrcode (~> 2.0)
+      savon (= 2.12.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
-    builder (3.2.3)
+    builder (3.2.4)
+    chunky_png (1.4.0)
     coderay (1.1.2)
     diff-lcs (1.3)
-    gyoku (1.3.1)
+    gyoku (1.4.0)
       builder (>= 2.1.2)
-    httpi (2.4.4)
+      rexml (~> 3.0)
+    httpi (2.5.0)
       rack
       socksify
     method_source (0.9.0)
     mini_portile2 (2.4.0)
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     nori (2.6.0)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (2.0.8)
+    public_suffix (4.0.7)
+    rack (3.0.2)
     rake (13.0.1)
+    rexml (3.2.5)
+    rqrcode (2.1.2)
+      chunky_png (~> 1.0)
+      rqrcode_core (~> 1.0)
+    rqrcode_core (1.2.0)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -41,7 +52,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.0)
-    savon (2.12.0)
+    savon (2.12.1)
       akami (~> 1.2)
       builder (>= 2.1.2)
       gyoku (~> 1.2)
@@ -51,7 +62,8 @@ GEM
       wasabi (~> 3.4)
     socksify (1.7.1)
     timecop (0.9.1)
-    wasabi (3.5.0)
+    wasabi (3.7.0)
+      addressable
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # CGIParty
-CGIParty is a gem made for integrating against the CGI Group GRP API.
-As of now you can only perform BankID authorisation.
+CGIParty is a gem made for integrating against the CGI Group GRP2 API.
+As of now you can only perform BankID authorization.
 
 - *You will need an agreement with CGI group in order to user their API. We do not provide this.*
+
+**NOTE: If you're still using the old GRP API, you'll need to install the old version ([1.0.0](https://github.com/standout/cgi-party/tree/v1.0.0)) of this gem.**
 
 ## Installation
 
@@ -48,15 +50,24 @@ the authenticate method. The authenticate response will contain information abou
 the authentication order.
 ```ruby
 client = CGIParty::Client.new
-authenticate_response = client.authenticate(social_security_number)
+authenticate_response = client.authenticate(ip_address)
 ```
-
+### Autostart on the same device
 You can acquire an url for prompting the BankID application on the device.
 ```ruby
 authenticate_response.autostart_url(return_url)
-#=> "bankid:///?autostarttoken=[token]&redirect=[return_url]"
+#=> "bankid:///?autostart=[token]&return=[return_url]"
 ```
 
+### QR code for BankID on another device
+Generate an animated QR code. You'll need some way to keep track of elapsed seconds as you refresh the QR code.
+```ruby
+client.generate_qr(start_token: authenticate_response.qr_start_token,
+                   start_secret: authenticate_response.qr_start_secret,
+                   seconds: seconds_elapsed)
+```
+
+### Collect
 To poll the collect action you can use the poll collect method. The block will be yielded
 every time the API responds. You can take appropriate action in your application by using the provided
 progress statuses.

--- a/cgi_party.gemspec
+++ b/cgi_party.gemspec
@@ -6,8 +6,8 @@ require "cgi_party/version"
 Gem::Specification.new do |spec|
   spec.name          = "cgi_party"
   spec.version       = CGIParty::VERSION
-  spec.authors       = ["Emric","Stavros"]
-  spec.email         = ["w.e.w@live.se","stavros.gemitzoglou@standout.se"]
+  spec.authors       = ["Emric","Stavros","Tobias"]
+  spec.email         = ["w.e.w@live.se","stavros.gemitzoglou@standout.se","tobias@almstrand.com"]
 
   spec.summary       = %q{Makes CGI Group GRP integration a party! <3}
   spec.homepage      = "https://github.com/standout/cgi-party"
@@ -29,7 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "savon", "~> 2.0"
+  spec.add_dependency "savon", "2.12.1"
+  spec.add_dependency "rqrcode", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.17.3"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/cgi_party/authenticate_request.rb
+++ b/lib/cgi_party/authenticate_request.rb
@@ -3,11 +3,10 @@ require "cgi_party/request"
 
 module CGIParty
   class AuthenticateRequest < CGIParty::Request
-    attr_reader :service_id, :display_name, :provider, :ssn
+    attr_reader :service_id, :display_name, :provider
 
-    def initialize(savon_client, ssn, ip_address, options: {})
+    def initialize(savon_client, ip_address, options: {})
       super(savon_client, ip_address, options)
-      @ssn = ssn
     end
 
     private
@@ -22,11 +21,10 @@ module CGIParty
 
     def message_hash
       {
-        display_name: @options[:display_name],
-        provider: @options[:provider],
         policy: @options[:service_id],
-        end_user_info: end_user_info,
-        personal_number: @ssn
+        provider: @options[:provider],
+        rp_display_name: @options[:display_name],
+        end_user_info: end_user_info
       }
     end
   end

--- a/lib/cgi_party/authenticate_response.rb
+++ b/lib/cgi_party/authenticate_response.rb
@@ -3,7 +3,7 @@ require "cgi_party/response"
 module CGIParty
   class AuthenticateResponse < Response
     def autostart_url(return_url)
-      "bankid:///?autostarttoken=#{auto_start_token}&redirect=#{return_url}"
+      "bankid:///?autostart=#{auto_start_token}&return=#{return_url}"
     end
   end
 end

--- a/lib/cgi_party/collect_request.rb
+++ b/lib/cgi_party/collect_request.rb
@@ -5,9 +5,9 @@ module CGIParty
   class CollectRequest < CGIParty::Request
     attr_reader :order_reference, :transaction_id
 
-    def initialize(savon_client, order_reference, ip_address,
+    def initialize(savon_client, order_reference,
                    transaction_id = nil, options: {})
-      super(savon_client, ip_address, options)
+      super(savon_client, options)
       @order_reference = order_reference
       @transaction_id = transaction_id
     end
@@ -19,14 +19,14 @@ module CGIParty
     end
 
     def available_options
-      %i[display_name service_id]
+      %i[display_name service_id provider]
     end
 
     def message_hash
       {
-        display_name: @options[:display_name],
         policy: @options[:service_id],
-        end_user_info: end_user_info,
+        provider: @options[:provider],
+        rp_display_name: @options[:display_name],
         transaction_id: @transaction_id,
         order_ref: @order_reference
       }

--- a/lib/cgi_party/request.rb
+++ b/lib/cgi_party/request.rb
@@ -1,19 +1,14 @@
 module CGIParty
   class Request
-    def initialize(savon_client, ip_address, options)
+    def initialize(savon_client, ip_address = nil, options)
       @options = fetch_options(options, available_options)
       @savon_client = savon_client
       @ip_address = ip_address
     end
 
     def execute
-      serialize_data(
-        @savon_client.call(
-          action_name,
-          message: message_hash,
-          message_tag: message_tag
-        ).body
-      )
+      response = @savon_client.call(action_name, message: message_hash, message_tag: message_tag, soap_action: false)
+      serialize_data(response.body)
     end
 
     private

--- a/lib/cgi_party/version.rb
+++ b/lib/cgi_party/version.rb
@@ -1,3 +1,3 @@
 module CGIParty
-  VERSION = "1.1.0"
+  VERSION = "2.0.0"
 end

--- a/lib/cgi_party/wsdl_paths.rb
+++ b/lib/cgi_party/wsdl_paths.rb
@@ -1,5 +1,5 @@
 module CGIParty
-  WSDL_PATH = "https://grp.funktionstjanster.se:8890/grp/v1?wsdl"
-  WSDL_TEST_PATH = "https://grpt.funktionstjanster.se:18898/grp/v1?wsdl"
-  WSDL_NAMESPACE = "http://funktionstjanster.se/grp/service/v1.0.0/"
+  WSDL_PATH = "https://grp.funktionstjanster.se:8890/grp/v2.1?wsdl"
+  WSDL_TEST_PATH = "https://grpt.funktionstjanster.se:18898/grp/v2.1?wsdl"
+  WSDL_NAMESPACE = "http://mobilityguard.com/grp/service/v2.0/"
 end

--- a/spec/authenticate_request_spec.rb
+++ b/spec/authenticate_request_spec.rb
@@ -3,26 +3,12 @@ require "cgi_party/authenticate_request"
 RSpec.describe CGIParty::AuthenticateRequest do
   let(:ip_address) { '127.0.0.1' }
 
-  describe ".initialize" do
-    it "sets ssn" do
-      ssn = "5907269129"
-
-      request =
-        CGIParty::AuthenticateRequest.new(CGIParty::Client.new.savon_client,
-                                          ssn,
-                                          ip_address)
-
-      expect(request.ssn).to eq ssn
-    end
-  end
-
   describe "#execute" do
     include Savon::SpecHelper
 
     it "calls the appropriate soap action" do
-      ssn = "5907269129"
       savon_client = spy("savon_client")
-      request = CGIParty::AuthenticateRequest.new(savon_client, ssn, ip_address)
+      request = CGIParty::AuthenticateRequest.new(savon_client, ip_address)
 
       request.execute
 
@@ -30,32 +16,29 @@ RSpec.describe CGIParty::AuthenticateRequest do
     end
 
     it "provides the necessary details" do
-      ssn = "5907269129"
       savon_client = spy("savon_client")
-      request = CGIParty::AuthenticateRequest.new(savon_client, ssn, ip_address)
+      request = CGIParty::AuthenticateRequest.new(savon_client, ip_address)
 
       request.execute
 
       expect(savon_client).to have_received(:call).with(
         :authenticate,
         message: {
-          display_name: CGIParty.config.display_name,
-          provider: CGIParty.config.provider,
           policy: CGIParty.config.service_id,
+          provider: CGIParty.config.provider,
+          rp_display_name: CGIParty.config.display_name,
           end_user_info: {
             type: 'IP_ADDR',
             value: '127.0.0.1'
-          },
-          personal_number: ssn,
-        }, message_tag: "AuthenticateRequest"
+          }
+        }, message_tag: "AuthenticateRequest", soap_action: false
       )
     end
 
     it "returns an order response" do
       savon.mock!
-      ssn = "5907269129"
       savon_client = CGIParty::Client.new.savon_client
-      request = CGIParty::AuthenticateRequest.new(savon_client, ssn, ip_address)
+      request = CGIParty::AuthenticateRequest.new(savon_client, ip_address)
       response_xml = File.read("spec/fixtures/authenticate_response.xml")
       savon.expects(:authenticate).with(message: :any).returns(response_xml)
 

--- a/spec/collect_request_spec.rb
+++ b/spec/collect_request_spec.rb
@@ -1,20 +1,16 @@
 require "cgi_party/collect_request"
 
 RSpec.describe CGIParty::CollectRequest do
-  let(:ip_address) { '127.0.0.1' }
-
   describe ".initialize" do
     it "sets the order reference" do
       expect(CGIParty::CollectRequest.new(CGIParty::Client.new.savon_client,
-                                          "order_reference",
-                                          ip_address).order_reference)
+                                          "order_reference").order_reference)
         .to eq("order_reference")
     end
 
     it "sets the transaction id if provided" do
       expect(CGIParty::CollectRequest.new(CGIParty::Client.new.savon_client,
                                           "order_reference",
-                                          ip_address,
                                           "transaction_id").transaction_id)
         .to eq("transaction_id")
     end
@@ -28,7 +24,6 @@ RSpec.describe CGIParty::CollectRequest do
       savon_client = spy("savon_client")
       request = CGIParty::CollectRequest.new(savon_client,
                                              "order_reference",
-                                             ip_address,
                                              "transaction_id")
 
       request.execute
@@ -41,21 +36,17 @@ RSpec.describe CGIParty::CollectRequest do
       savon_client = spy("savon_client")
       request = CGIParty::CollectRequest.new(savon_client,
                                              "order_reference",
-                                             ip_address,
                                              "transaction_id")
 
       request.execute
 
       expect(savon_client).to have_received(:call).with(:collect, message: {
         policy: CGIParty.config.service_id,
-        end_user_info: {
-          type: 'IP_ADDR',
-          value: '127.0.0.1'
-        },
+        provider: CGIParty.config.provider,
+        rp_display_name: CGIParty.config.display_name,
         transaction_id: "transaction_id",
         order_ref: "order_reference",
-        display_name: CGIParty.config.display_name
-      }, message_tag: "CollectRequest")
+      }, message_tag: "CollectRequest", soap_action: false)
     end
 
     it "returns a collect response" do
@@ -63,9 +54,8 @@ RSpec.describe CGIParty::CollectRequest do
       savon_client = CGIParty::Client.new.savon_client
       request = CGIParty::CollectRequest.new(savon_client,
                                              "order_reference",
-                                             ip_address,
                                              "transaction_id")
-      response_xml = File.read("spec/fixtures/authenticate_response.xml")
+      response_xml = File.read("spec/fixtures/collect_response.xml")
       savon.expects(:collect).with(message: :any).returns(response_xml)
 
       result = request.execute

--- a/spec/fixtures/authenticate_response.xml
+++ b/spec/fixtures/authenticate_response.xml
@@ -1,9 +1,11 @@
-<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
-   <S:Body>
-      <ns2:AuthenticateResponse xmlns:ns2="http://funktionstjanster.se/grp/service/v1.0.0/">
-         <transactionId>e7a5c17c</transactionId>
-         <orderRef>c87ebe55-0d1d-4d37-a5ed-c0b65f88c4e4</orderRef>
-         <AutoStartToken>45216ad0-320a-4de5-b4a3-bac28de5c173</AutoStartToken>
-      </ns2:AuthenticateResponse>
+<S:Envelope xmlns:S="http://www.w3.org/2003/05/soap-envelope/" xmlns:env="http://www.w3.org/2003/05/soap-envelope/">
+   <S:Body xmlns:ns2="http://mobilityguard.com/grp/service/v2.0/" xmlns:ns3="http://mobilityguard.com/grp/service/v2.1/">
+      <ns3:AuthenticateResponse xmlns:ns3="http://mobilityguard.com/grp/service/v2.1/">
+         <transactionId>115bd0b7</transactionId>
+         <orderRef>b0b105af-adbe-49b7-9fa9-d3658808cbbc</orderRef>
+         <AutoStartToken>b1e91bc1-6220-4d34-94b5-41e742e64e7e</AutoStartToken>
+         <qrStartToken>69735e5c-a670-4c2e-bf1e-7cc6076b662f</qrStartToken>
+         <qrStartSecret>71f56c2a-9f8e-49f9-8655-38453781fd47</qrStartSecret>
+      </ns3:AuthenticateResponse>
    </S:Body>
 </S:Envelope>

--- a/spec/fixtures/collect_response.xml
+++ b/spec/fixtures/collect_response.xml
@@ -1,8 +1,8 @@
-<S:Envelope xmlns:S="http://schemas.xmlsoap.org/soap/envelope/">
-   <S:Body>
-      <ns2:CollectResponse xmlns:ns2="http://funktionstjanster.se/grp/service/v1.0.0/">
-         <transactionId>e7a5c17c</transactionId>
-         <progressStatus>COMPLETE</progressStatus>
+<S:Envelope xmlns:S="http://www.w3.org/2003/05/soap-envelope/" xmlns:env="http://www.w3.org/2003/05/soap-envelope/">
+   <S:Body xmlns:ns2="http://mobilityguard.com/grp/service/v2.0/" xmlns:ns3="http://mobilityguard.com/grp/service/v2.1/">
+      <ns2:CollectResponse xmlns:ns2="http://mobilityguard.com/grp/service/v2.0/">
+         <transactionId>d9b3b28</transactionId>
+         <progressStatus>USER_SIGN</progressStatus>
       </ns2:CollectResponse>
    </S:Body>
 </S:Envelope>


### PR DESCRIPTION
Enables secure start:
- Autostart when the e-service and BankID are used on the same device, or
- Animated QR code when the e-service and BankID are used on separate devices